### PR TITLE
fix total attribute length being written to wrong position

### DIFF
--- a/stack/avrc/avrc_bld_tg.c
+++ b/stack/avrc/avrc_bld_tg.c
@@ -976,7 +976,8 @@ static tAVRC_STS avrc_bld_get_attrs_rsp (tAVRC_GET_ATTRS_RSP *p_rsp, BT_HDR *p_p
     }
     /* get the existing length, if any, and also the num attributes */
     p_start = (uint8_t *)(p_pkt + 1) + p_pkt->offset;
-    p_data = p_len = p_start + 1; /* pdu */
+    p_data = p_start + 1; /* pdu */
+    p_len = p_start + 2;
     /* the existing len */
     BE_STREAM_TO_UINT16(len, p_data);
     p_num = p_data + 1;
@@ -993,6 +994,7 @@ static tAVRC_STS avrc_bld_get_attrs_rsp (tAVRC_GET_ATTRS_RSP *p_rsp, BT_HDR *p_p
     {
         p_data = p_start + p_pkt->len;
     }
+    len = 2;
     for (uint8_t xx = 0; (xx < p_rsp->num_attrs) && (len_left > 9); xx++)
     {
         (*p_num)++;


### PR DESCRIPTION
Previous change broke metadata being sent to car recevier because the position of the length sent before the attributes was off by one.  Also it looks like in some cases the length is not reset before calculating it again.  I am not an expert at this code but this fix did fix the metadata getting sent correctly.